### PR TITLE
[Travis] Use "build-for-testing" and "test-without-building" build actions on Xcode 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,17 @@ matrix:
       osx_image: xcode8
       env:
         - PLATFORM=osx
+        - XCODE_ACTION="build-for-testing test-without-building"
     - os: osx
       osx_image: xcode8
       env:
         - PLATFORM=ios
+        - XCODE_ACTION="build-for-testing test-without-building"
     - os: osx
       osx_image: xcode8
       env:
         - PLATFORM=tvos
+        - XCODE_ACTION="build-for-testing test-without-building"
     - os: osx
       sudo: required
       env:

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,10 @@ def has_xcodebuild
   system "which xcodebuild >/dev/null"
 end
 
+def xcode_action
+  ENV["XCODE_ACTION"] || "test"
+end
+
 namespace "podspec" do
   desc "Run lint for podspec"
   task :lint do
@@ -16,17 +20,17 @@ end
 namespace "test" do
   desc "Run unit tests for all iOS targets"
   task :ios do |t|
-    run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-iOS -destination 'platform=iOS Simulator,name=iPhone 6' clean test"
+    run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-iOS -destination 'platform=iOS Simulator,name=iPhone 6' clean #{xcode_action}"
   end
 
   desc "Run unit tests for all tvOS targets"
   task :tvos do |t|
-    run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-tvOS -destination 'platform=tvOS Simulator,name=Apple TV 1080p' clean test"
+    run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-tvOS -destination 'platform=tvOS Simulator,name=Apple TV 1080p' clean #{xcode_action}"
   end
 
   desc "Run unit tests for all OS X targets"
   task :osx do |t|
-    run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-OSX clean test"
+    run "xcodebuild -workspace Quick.xcworkspace -scheme Quick-OSX clean #{xcode_action}"
   end
 
   desc "Run unit tests for the current platform built by the Swift Package Manager"


### PR DESCRIPTION
One more thing for Xcode 8 support. This should stabilize running iOS and tvOS tests on Travis with Xcode 8.
